### PR TITLE
ValidationError Update

### DIFF
--- a/src/lib/error.js
+++ b/src/lib/error.js
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 TechnologyAdvice
  */
+import util from 'util'
 
 /**
  * Compiles array items into string error messages
@@ -25,11 +26,10 @@ function ValidationError(message) {
   Object.defineProperty(this, 'name', { value: 'ValidationError' })
   Object.defineProperty(this, 'message', { value: getMessages(message).join('\n') })
   Object.defineProperty(this, 'collection', { value: message })
-  Error.captureStackTrace(this, this.name)
+  Error.captureStackTrace(this, ValidationError)
 }
 
 // Creates instance of ValidationError as Error object
-ValidationError.prototype = Object.create(Error.prototype)
-ValidationError.prototype.constructor = ValidationError
+util.inherits(ValidationError, Error)
 
 export default ValidationError

--- a/test/src/lib/error.spec.js
+++ b/test/src/lib/error.spec.js
@@ -2,8 +2,14 @@
 import ValidationError from 'src/lib/error'
 
 describe('ValidationError', () => {
+  it('inherits from Error', () => {
+    expect(new ValidationError([])).to.be.instanceOf(Error)
+  })
   it('creates a new instance of ValidationError', () => {
     expect(new ValidationError([])).to.be.instanceOf(ValidationError)
+  })
+  it('contains stack property', () => {
+    expect(new ValidationError([])).to.have.property('stack')
   })
   it('creates an error without a key if key is not present', () => {
     const origError = [
@@ -20,5 +26,12 @@ describe('ValidationError', () => {
     const err = new ValidationError(origError)
     expect(err.message).to.equal('foo (bar): Not ok\nfizz (buzz): Nope')
     expect(err.collection).to.deep.equal(origError)
+  })
+  it('does not include ValidationError on stack', () => {
+    const sampleError = [
+        { value: 'bar', message: 'Not ok'}
+    ]
+    const err = new ValidationError(sampleError)
+    expect(err.stack).to.not.contain('error.js')
   })
 })


### PR DESCRIPTION
- Add test to make sure `ValidationError` inherits from `Error`.
- use `inherits` method from [`util`](https://nodejs.org/dist/latest-v4.x/docs/api/util.html#util_util_inherits_constructor_superconstructor) module.
- omit `ValidationError` from [generated stack trace](https://nodejs.org/dist/latest-v4.x/docs/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt).
- add test to make sure `ValidationError` is not included in `stack` property.