### PR TITLE
Fix Safari error: Error.captureStackTrace is not a function

### DIFF
--- a/src/lib/error.js
+++ b/src/lib/error.js
@@ -26,7 +26,13 @@ function ValidationError(message) {
   Object.defineProperty(this, 'name', { value: 'ValidationError' })
   Object.defineProperty(this, 'message', { value: getMessages(message).join('\n') })
   Object.defineProperty(this, 'collection', { value: message })
-  Error.captureStackTrace(this, ValidationError)
+
+  // Fixes captureStackTrace missing on Safari
+  if (typeof Error.captureStackTrace === 'function') {
+    Error.captureStackTrace(this, ValidationError)
+  } else {
+    this.stack = new Error().stack
+  }
 }
 
 // Creates instance of ValidationError as Error object


### PR DESCRIPTION
It's [common issue](https://github.com/search?q=Safari+captureStackTrace&type=Issues&utf8=%E2%9C%93) with Safari.
Ah, and here [your snippet](https://css-tricks.com/snippets/javascript/check-if-function-exists-before-calling/#comment-184074) ;-)