### PR TITLE
fix(array-return): if array values not defined, return original value

### DIFF
--- a/src/typeStrategies/array.js
+++ b/src/typeStrategies/array.js
@@ -16,7 +16,7 @@ const array = {
       return context.fail('Value must not be empty array')
     }
     // Specific array sub-validation
-    if (!context.def.values) return true
+    if (!context.def.values) return context.value
     const promises = context.value.map((elem, idx) => {
       return rules.validate(context.def.values, elem, context.def.opts, `${context.key}[${idx}]`, context.errors, false, context.initData)
     })

--- a/test/src/typeStrategies/array.spec.js
+++ b/test/src/typeStrategies/array.spec.js
@@ -1,7 +1,7 @@
 /* global describe, it, expect, sinon */
 import array from 'src/typeStrategies/array'
 
-describe.only('type:array', () => {
+describe('type:array', () => {
   it('calls context.fail if type is not an array', () => {
     const context = {
       value: 'foo',

--- a/test/src/typeStrategies/array.spec.js
+++ b/test/src/typeStrategies/array.spec.js
@@ -1,7 +1,7 @@
 /* global describe, it, expect, sinon */
 import array from 'src/typeStrategies/array'
 
-describe('type:array', () => {
+describe.only('type:array', () => {
   it('calls context.fail if type is not an array', () => {
     const context = {
       value: 'foo',
@@ -16,8 +16,9 @@ describe('type:array', () => {
       fail: sinon.spy(),
       def: {}
     }
-    array.default(context)
+    const actual = array.default(context)
     expect(context.fail).to.not.be.called
+    expect(actual).to.deep.equal(context.value)
   })
   it('allows an empty array to pass if empty flag is set to true', () => {
     const context = {


### PR DESCRIPTION
This fixes "loose" array definitions (i.e. just specifying `type: 'array'` without declaring the array items' types). Has bitten us in the ass a few times.